### PR TITLE
Use caller() instead of module.parent.filename to determine calling module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 "use strict";
 var path = require("path")
+var caller = require('caller');
 
 module.exports = function (toLoad, mocks) {
   // Copy the existing cache
@@ -30,8 +31,9 @@ var installGlobally = module.exports.installGlobally = function (toLoad, mocks) 
     }
   })
 
+  var callerFilename = caller() == module.filename ? caller(2) : caller();
   if (/^[.][.]?\//.test(toLoad)) {
-    toLoad = path.resolve(path.dirname(module.parent.filename), toLoad)
+    toLoad = path.resolve(path.dirname(callerFilename), toLoad)
   }
   var toLoadPath = require.resolve(toLoad)
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,6 @@ var installGlobally = module.exports.installGlobally = function (toLoad, mocks) 
 
   // remove any unmocked version previously loaded
   delete require.cache[toLoadPath]
-
   // load our new version using our mocks
-  return module.parent.require(toLoadPath)
+  return require.cache[callerFilename].require(toLoadPath);
 }

--- a/package.json
+++ b/package.json
@@ -21,5 +21,8 @@
   "license": "ISC",
   "devDependencies": {
     "tap": "^0.4.13"
+  },
+  "dependencies": {
+    "caller": "^1.0.1"
   }
 }


### PR DESCRIPTION
This means that even the second module to require require-inject will have the correct relative path for modules it loads with `../../`
