### PR TITLE
Inject relative path

### DIFF
--- a/test/injection-paths.js
+++ b/test/injection-paths.js
@@ -1,0 +1,32 @@
+'use strict'
+
+var test = require('tap').test
+var requireInject = require('../index')
+
+test('mock with absolute path', function (t) {
+  t.plan(1)
+
+  var a = requireInject('./lib/a', {
+    [require.resolve('./lib/b')]: function (infile, outfile, cb) {
+      cb()
+    }
+  })
+
+  a('in', 'out', function (err) {
+    t.notOk(err, 'should be able to rename a file')
+  })
+})
+
+test('mock with relative path', function (t) {
+  t.plan(1)
+
+  var a = requireInject('./lib/a', {
+    './lib/b': function (infile, outfile, cb) {
+      cb()
+    }
+  })
+
+  a('in', 'out', function (err) {
+    t.notOk(err, 'should be able to rename a file')
+  })
+})


### PR DESCRIPTION
In this PR, `require-inject` is updated to deal with relative paths for mocks.

I've been using `require-inject` for a while to mock not only standard node modules, but also modules in the project under test. However, to be able to do this, the absolute paths to the module being mocked must be passed with the current implementation:

```node
const requireInject = require('require-inject')

const mocks = {
    [require.resolve('./lib/a')]: <a mock>,
    [require.resolve('./lib/b')]: <another mock>
}
```  

Typing all this path resolution process quickly becomes tedious so, to address this problem, the resolution is moved to `require-inject` in this PR and relative imports can be used:
```node
const requireInject = require('require-inject')

const mocks = {
    './lib/a': <a mock>,
    './lib/b': <another mock>
}
```  
