### PR TITLE
Mock module a bit better.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict'
+var Module = require('module')
 var path = require('path')
 var caller = require('caller')
 
@@ -59,6 +60,7 @@ function getCallerFilename () {
 
 function installGlobally (toLoad, mocks) {
   var callerFilename = getCallerFilename()
+  var parent = require.cache[toLoadPath] || null
 
   // Inject all of our mocks
   Object.keys(mocks).forEach(function (name) {
@@ -66,7 +68,12 @@ function installGlobally (toLoad, mocks) {
     if (mocks[name] == null) {
       delete require.cache[namePath]
     } else {
-      require.cache[namePath] = {exports: mocks[name]}
+      var old = require.cache[namePath]
+      var mod = new Module(namePath, null)
+      mod.filename = namePath
+      mod.exports = mocks[name]
+      mod.parent = old ? old.parent : parent
+      require.cache[namePath] = mod
     }
   })
 

--- a/test/injection-module.js
+++ b/test/injection-module.js
@@ -1,0 +1,59 @@
+'use strict'
+var path = require('path')
+var test = require('tap').test
+var Tacks = require('tacks')
+var File = Tacks.File
+var Dir = Tacks.Dir
+var requireInject = require('../index')
+
+var testdir = path.join(__dirname, path.basename(__filename, '.js'))
+var adir = path.join(testdir, 'a')
+var bdir = path.join(testdir, 'b')
+var bfilename = bdir + '.js'
+
+var fixture = new Tacks(
+  Dir({
+    'a.js': File(
+      "'use strict';\n" +
+      "require('./b');\n"
+    ),
+    'b.js': File('')
+  })
+)
+
+test('setup', function (t) {
+  fixture.create(testdir)
+  t.end()
+})
+
+test('mock with details of original module', function (t) {
+  t.plan(3)
+
+  var bmod
+
+  Object.defineProperty(require.cache, bfilename, {
+    configurable: true,
+    enumerable: true,
+    get () {
+      return bmod
+    },
+    set (value) {
+      bmod = value
+    }
+  })
+
+  require(bdir)
+
+  requireInject(adir, {
+    [bdir]: 'mock'
+  })
+
+  t.equal(bmod.filename, bfilename)
+  t.equal(bmod.id, bfilename)
+  t.equal(bmod.parent, require.cache[__filename])
+})
+
+test('cleanup', function (t) {
+  fixture.remove(testdir)
+  t.end()
+})


### PR DESCRIPTION
This PR mocks the `module` object a bit better to provide it with things that are expected of it from the module system. This gives other loaders that might handle the mocked module a bit more context.