### PR TITLE
fix: native modules should not be restored

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,12 @@ var requireInject = function (toLoad, mocks, withEmptyCache) {
 
   // restore the cache, we can't just assign originalCache to require.cache as the require
   // object is unique to each module, even though require.cache is shared
-  Object.keys(require.cache).forEach(function (name) { delete require.cache[name] })
+  Object.keys(require.cache).forEach(function (name) {
+    // native modules should not be reloaded.
+    if (!name.match(/\.node$/)) {
+      delete require.cache[name]
+    }
+  })
   Object.keys(originalCache).forEach(function (name) { require.cache[name] = originalCache[name] })
 
   return mocked

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "standard",
-    "test": "tap test/*.js",
+    "test": "tap --no-esm test/*.js",
     "prerelease": "npm t",
     "release": "standard-version -s",
     "postrelease": "npm publish && git push --follow-tags",


### PR DESCRIPTION
deleting native modules (`.node` extension) from the require cache is not supported, from docs:


> Modules are cached in this object when they are required. By deleting a key value from this object, the next require will reload the module. Note that this does not apply to native addons, for which reloading will result in an error.

we bumped into this issue in one of our modules.