### PR TITLE
fix: stop using deprecated module.parent

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,6 @@ function getCallerFilename () {
 
 function installGlobally (toLoad, mocks) {
   var callerFilename = getCallerFilename()
-  var parent = require.cache[toLoadPath] || null
 
   // Inject all of our mocks
   Object.keys(mocks).forEach(function (name) {
@@ -74,12 +73,10 @@ function installGlobally (toLoad, mocks) {
     if (mocks[name] == null) {
       delete require.cache[namePath]
     } else {
-      var old = require.cache[namePath]
       var mod = new Module(namePath, null)
       mod.filename = namePath
       mod.exports = mocks[name]
       mod.loaded = true
-      mod.parent = old ? old.parent : parent
       require.cache[namePath] = mod
     }
   })


### PR DESCRIPTION
<!--
⚠️🚨 BEFORE FILING A PR: 🚨⚠️

👉🏼 CONTRIBUTING.md 👈🏼 (the "contribution guidelines" up there ☝🏼)

I PROMISE IT'S A VERY VERY SHORT READ.🙇🏼 <= IT'S NOT THOUGH!
-->

`module.parent` is deprecated as of Node.js v14.6.0, and is read-only on Node.js v15.0.0-pre.